### PR TITLE
Improving sorting of funding calls

### DIFF
--- a/_includes/funds-collection.html
+++ b/_includes/funds-collection.html
@@ -13,6 +13,9 @@
   {% elsif include.sort_by == 'title' %}
     {% assign entries = entries | sort: 'title' %}
   {% endif %}
+  {% if include.sort_order == 'latest' %}
+    {% assign entries = entries | reverse %}
+  {% endif %}
 
   {% for entry in entries %}
 

--- a/_layouts/funds-collection.html
+++ b/_layouts/funds-collection.html
@@ -14,7 +14,7 @@ layout: title-page
 
 <div class="landscape-block-group">
   <div class="events-block-group__inner-container">
-    {% include funds-collection.html collection=page.collection format="deadline" sort_by=page.sort_by sort_order=page.sort_order archive=false %}
+    {% include funds-collection.html collection=page.collection format="deadline" sort_by="closing_deadline" sort_order="earliest" archive=false %}
   </div>
 </div>
 
@@ -23,7 +23,7 @@ layout: title-page
 
 <div class="landscape-block-group">
   <div class="events-block-group__inner-container">
-    {% include funds-collection.html collection=page.collection format="open" sort_by=page.sort_by sort_order=page.sort_order %}
+    {% include funds-collection.html collection=page.collection format="open" sort_by="title" sort_order=page.sort_order %}
   </div>
 </div>
 
@@ -32,7 +32,7 @@ layout: title-page
 
 <div class="landscape-block-group">
   <div class="events-block-group__inner-container">
-    {% include funds-collection.html collection=page.collection format="future" sort_by=page.sort_by sort_order=page.sort_order %}
+    {% include funds-collection.html collection=page.collection format="future" sort_by="title" sort_order=page.sort_order %}
   </div>
 </div>
 
@@ -41,6 +41,6 @@ layout: title-page
 
 <div class="landscape-block-group">
   <div class="events-block-group__inner-container">
-    {% include funds-collection.html collection=page.collection format="deadline" sort_by=page.sort_by sort_order=page.sort_order archive=true %}
+    {% include funds-collection.html collection=page.collection format="deadline" sort_by="closing_deadline" sort_order="latest" archive=true %}
   </div>
 </div>


### PR DESCRIPTION
Calls with a closing deadline were not sorted in date order, but randomly.

- Pass valid sort_by to funds include
- Closed calls should be listed most recently closed first; open calls with the earliest deadline first