### PR TITLE
Fix link

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -40,5 +40,5 @@ feature_row:
 {% include feature_row %}    
 
 <div style="text-align: center; margin-top: 2rem;">
-  <a href="{{ '//about/who-are-we#get-involved/' | relative_url }}" class="btn btn--secondary btn--large">How to get involved with CAKE</a>
+  <a href="/about/who-are-we#get-involved/" class="btn btn--secondary btn--large">How to get involved with CAKE</a>
 </div>


### PR DESCRIPTION
Fixes #93 .

I changed the link to hopefully now correctly point to the "get involved" section on the "about" page.