### PR TITLE
Add Fortran index hackathon 7

### DIFF
--- a/_pages/ke-fellowships/ke-fellows-cohort1.md
+++ b/_pages/ke-fellowships/ke-fellows-cohort1.md
@@ -19,7 +19,7 @@ We are looking forward to see how their projects will develop over the coming ye
 
 ### Fortran index: Facilitating better knowledge exchange within the Fortran community
 
-Many high quality learning resources and tools have been developed for the Fortran programming language over its seven decades of usage. However, their visibility is generally poor in the community. This fellowship builds on the work of the [Fortran index](https://github.com/fortran-index/fortran-index) hackathon series to facilitate better sharing of knowledge by adding to, correcting, and curating the information presented in the [fortran-lang](https://fortran-lang.org/) community resource.
+Many high quality learning resources and tools have been developed for the Fortran programming language over its seven decades of usage. However, their visibility is generally poor in the community. This fellowship builds on the work of the [Fortran index](https://fortran-index.github.io) hackathon series to facilitate better sharing of knowledge by adding to, correcting, and curating the information presented in the [fortran-lang](https://fortran-lang.org/) community resource.
 
 ## Lewis Sampson
 

--- a/collections/_events/202607-FortranIndexHackathon7.md
+++ b/collections/_events/202607-FortranIndexHackathon7.md
@@ -1,0 +1,29 @@
+---
+title: "Fortran Index hackathon 7"
+icon_alt: Award icon
+categories:
+  - National
+group: events
+date: 2026-07-22
+layout: event
+image: https://fortran-index.github.io/fortran-index/media/Fortran_index.svg
+project-type: National Event
+web-page: https://forms.gle/7QjJjs5cDPt2Pbwg9
+location: Online
+summary: Fortran index hackathon focusing on improving fortran-lang's package index
+---
+
+The [Fortran index](https://github.com/fortran-index/fortran-index) hackathon
+series aims to improve knowledge exchange within the Fortran programming
+community by adding, correcting, and curating the information available in the
+[fortran-lang](https://fortran-lang.org) community resource.
+
+In this edition, we will continue work on overhauling the
+[package index](https://fortran-lang.org/packages/) to make it more useful for
+the Fortran community, e.g., more easily searchable and perhaps with
+finer-grained sections.
+
+The event will be hosted online, running on Wednesday 22nd July 2026 between
+14:00 and 16:30 BST (13:00-15:30 UTC). Register for the hackathon by filling out
+the following form:
+[https://forms.gle/7QjJjs5cDPt2Pbwg9](https://forms.gle/7QjJjs5cDPt2Pbwg9).


### PR DESCRIPTION
This PR adds the upcoming Fortran index hackathon to the events listing.